### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ resources:
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py36]
+    toxenvs: [py37]
     os: windows
     architectures: [x64, x86]
     wheel_tags: true
@@ -26,5 +26,5 @@ jobs:
     wheel_tags: true
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38, py39]
+    toxenvs: [py37, py38, py39]
     os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -27,7 +26,7 @@ classifiers =
 py_modules = ukkonen
 install_requires =
     cffi>=1
-python_requires = >=3.6.1
+python_requires = >=3.7
 setup_requires =
     cffi>=1
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import sys
 

--- a/tests/ukkonen_test.py
+++ b/tests/ukkonen_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ukkonen import distance
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt

--- a/ukkonen.py
+++ b/ukkonen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import _ukkonen
 
 _lib = _ukkonen.lib

--- a/ukkonen_build.py
+++ b/ukkonen_build.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cffi import FFI
 
 CDEF = '''\


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos