### PR TITLE
Enable building with free-threaded CPython 3.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import platform
 import sys
+import sysconfig
 
 from setuptools import setup
 
-if platform.python_implementation() == 'CPython':
+if (
+        platform.python_implementation() == 'CPython' and
+        sysconfig.get_config_var('Py_GIL_DISABLED') != 1
+):
     try:
         import wheel.bdist_wheel
     except ImportError:


### PR DESCRIPTION
According to [this](https://github.com/python-cffi/cffi/releases/tag/v2.0.0), ccfi>=2.0.0 supports building with free-threaded CPython 3.14. cffi 2.0.0 has been released in September 9, 2025 (4 months ago at the time of writing).

With this change, I can build fine with free-threaded CPython 3.14.

On `main` you get an error because free-threaded does not use the limited ABI
```
ValueError: `py_limited_api='cp314'` not supported. `Py_LIMITED_API` is currently incompatible with `Py_GIL_DISABLED`. See https://github.com/python/cpython/issues/111506.
error: subprocess-exited-with-error
```

I did test locally that the tests were passing with free-threaded CPython 3.14:
```
pytest tests
```
and also that the tests ran fine with [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel) 
```
pytest --parallel-threads 10 --iterations 1000 tests
```

Let me know if you would like to see more things. A few things I can think of:
- require cffi>=2 for free-threaded CPython 3.14. Not sure if this can be done easily in `setup.cfg` ...
- add CI for free-threaded CPython 3.14
- user-friendly error for free-threaded CPython 3.13 since apparently cffi 2.0.0 only added support for free-threaded CPython 3.14 not 3.13.